### PR TITLE
Correctly reset 'hide_children_in_tree'

### DIFF
--- a/core/components/gridclasskey/elements/plugins/gridclasskey.plugin.php
+++ b/core/components/gridclasskey/elements/plugins/gridclasskey.plugin.php
@@ -44,8 +44,8 @@ switch ($modx->event->name) {
             if ($classKey !== 'GridContainer' &&
                     $isHideChildren == 1
             ) {
-                $properties = $resource->getProperties('gridclasskey');
-                if ($properties) {
+                $properties = $resource->get('properties');
+                if ($properties['gridclasskey'] || empty($properties['gridclasskey'])) {
                     $resource->set('hide_children_in_tree', 0);
                     $resource->save();
                 }


### PR DESCRIPTION
Correctly reset the 'hide_children_in_tree' property to 0 when changing Resource Type coming from an empty Grid Container: {"gridclasskey":[]} (take note of the square brackets) or a Grid Container with some configs:  {"gridclasskey":{ /\* grid configs here */ }} (we have curly brackets)
