### PR TITLE
Fix MODX version comparing issues

### DIFF
--- a/core/components/gridclasskey/elements/plugins/gridclasskey.plugin.php
+++ b/core/components/gridclasskey/elements/plugins/gridclasskey.plugin.php
@@ -126,8 +126,8 @@ switch ($modx->event->name) {
     case 'OnDocFormPrerender':
         $action = $_GET['a'];
         $vers = $modx->getVersionData();
-        $ver_comp = version_compare($vers['full_version'], '2.3.0');
-        if ($ver_comp > 0) {
+        $ver_comp = version_compare($vers['version'].'.'.$vers['major_version'].'.'.$vers['minor_version'], '2.3.0');
+        if ($ver_comp >= 0) {
             if ($action !== 'resource/create' && $action !== 'resource/update') {
                 return false;
             }


### PR DESCRIPTION
`$vers['full_version']` includes also suffixes like "-dev" which breaks version_compare().

Also version_compare() returns `0` if the versions are equal so line 130 must be `>=`.
