### PR TITLE
fix wrong strftime format

### DIFF
--- a/core/components/gridclasskey/processors/mgr/classkey/children/getlist.class.php
+++ b/core/components/gridclasskey/processors/mgr/classkey/children/getlist.class.php
@@ -270,8 +270,8 @@ class GridContainerGetListProcessor extends modResourceGetListProcessor {
         if (isset($resourceArray['publishedon'])) {
             $publishedon = strtotime($resourceArray['publishedon']);
             $resourceArray['publishedon_date'] = strftime($this->modx->getOption('gridclasskey.mgr_date_format', null, '%b %d'), $publishedon);
-            $resourceArray['publishedon_time'] = strftime($this->modx->getOption('gridclasskey.mgr_time_format', null, '%H:%I %p'), $publishedon);
-            $resourceArray['publishedon'] = strftime('%b %d, %Y %H:%I %p', $publishedon);
+            $resourceArray['publishedon_time'] = strftime($this->modx->getOption('gridclasskey.mgr_time_format', null, '%I:%M %p'), $publishedon);
+            $resourceArray['publishedon'] = strftime('%b %d, %Y %I:%M %p', $publishedon);
         }
 
         if (!empty($this->parentProperties)) {


### PR DESCRIPTION
The format for strftime was very wrong which results in an issue where you can customize the values with an output filter.

I have no idea why you're changing the format for (and only for) publishedon, since it's very easy to do with output filter. But at least this change makes it possible to customize it again. :)