### PR TITLE
Fix font-style for check-boxes, MODX 2.3.x

### DIFF
--- a/assets/components/gridclasskey/css/mgr.css
+++ b/assets/components/gridclasskey/css/mgr.css
@@ -147,3 +147,7 @@
 #gridclasskey-panel-settings .x-column:only-child {
     margin: 0;
 }
+
+#gridclasskey-grid-children .x-grid3-row-checker {
+	font-style: normal;
+}


### PR DESCRIPTION
This PR fixes the following issue:

Before:
![screenshot_101714_092140_pm](https://cloud.githubusercontent.com/assets/114390/4682233/e0562c0a-561a-11e4-814c-b982da8f01f2.jpg)

After:
![screenshot_101714_092034_pm](https://cloud.githubusercontent.com/assets/114390/4682236/e70dfaaa-561a-11e4-9977-4d6797d62f21.jpg)
